### PR TITLE
Feat: remove hard code check for detecting master variant

### DIFF
--- a/src/coffee/mapping.coffee
+++ b/src/coffee/mapping.coffee
@@ -24,9 +24,9 @@ class Mapping
     rowIndex = raw.startRow
 
     product = @mapBaseProduct raw.master, productType, rowIndex
-    product.masterVariant = @mapVariant raw.master, 1, productType, rowIndex, product
+    product.masterVariant = @mapVariant raw.master, Number(raw.master[@header.toIndex CONS.HEADER_VARIANT_ID]), productType, rowIndex, product
     _.each raw.variants, (entry, index) =>
-      product.variants.push @mapVariant entry.variant, index + 2, productType, entry.rowIndex, product
+      product.variants.push @mapVariant entry.variant, Number(entry.variant[@header.toIndex CONS.HEADER_VARIANT_ID]), productType, entry.rowIndex, product
 
     data =
       product: product

--- a/src/coffee/validator.coffee
+++ b/src/coffee/validator.coffee
@@ -202,17 +202,14 @@ class Validator
 
   isVariant: (row, variantColumn) ->
     if variantColumn is CONS.HEADER_VARIANT_ID
-      variantId = row[@header.toIndex(CONS.HEADER_VARIANT_ID)]
-      parseInt(variantId) > 1
+      hasProductTypeColumn = not _.isBlank(row[@header.toIndex(CONS.HEADER_PRODUCT_TYPE)])
+      return !hasProductTypeColumn
     else
       not @isProduct row
 
   isProduct: (row, variantColumn) ->
     hasProductTypeColumn = not _.isBlank(row[@header.toIndex(CONS.HEADER_PRODUCT_TYPE)])
-    if variantColumn is CONS.HEADER_VARIANT_ID
-      hasProductTypeColumn and row[@header.toIndex(CONS.HEADER_VARIANT_ID)] is '1'
-    else
-      hasProductTypeColumn
+    return hasProductTypeColumn
 
   _hasVariantCriteria: (row, variantColumn) ->
     critertia = row[@header.toIndex(variantColumn)]


### PR DESCRIPTION
#### Feat: remove hard code check for detecting master variant

Background :- Earlier we were assuming that master variant will have id 1. However when user makes any variant(earlier which was not master variant) to master variant then this assumption becomes wrong. 

Fix:
To fix the above solution I have removed this hard code check and relying on the csv format to detect the master variant and other variants. So master variant will have the product type but other variants will have the product type value empty.

Example
```
      productType,variantId,sku,variantKey,hand-wash,prices,images,size,color
     T-shirt,3,8888gfg,B2fggf,true,USD 12,http://asdasd.com,medium,black -----This is master variant because product type is mentioned
      ,2,32453535435435,34324234234,true,USD 13,http://asdasd.com,x-large,white -----This is non master variant because product type is missing and there is a product type row above.
      ,1,2343244324,2342342,false,USD 14,http://asdasd.com,x-large,black
     T-shirt,2,2222222,2222222,true,USD 21,http://asdasd.com,x-large,white
      ,1,111111,111111,true,USD 22,http://asdasd.com,x-large,black
```
@ashishhk Pease let me know your views on this. 

Fix: https://github.com/commercetools/sphere-node-product-csv-sync/issues/306 
