### PR TITLE
feat: support change master variant

### DIFF
--- a/src/coffee/import.coffee
+++ b/src/coffee/import.coffee
@@ -476,7 +476,7 @@ class Import
         when 'setSku' then header.has(CONS.HEADER_SKU)
         when 'setProductVariantKey' then header.has(CONS.HEADER_VARIANT_KEY)
         when 'setKey' then header.has(CONS.HEADER_KEY)
-        when 'addVariant', 'addPrice', 'removePrice', 'changePrice', 'addExternalImage', 'removeImage', 'setImageLabel', 'moveImageToPosition' then true
+        when 'addVariant', 'addPrice', 'removePrice', 'changePrice', 'addExternalImage', 'removeImage', 'setImageLabel', 'moveImageToPosition', 'changeMasterVariant' then true
         when 'removeVariant' then @allowRemovalOfVariants
         else throw Error "The action '#{action.action}' is not supported. Please contact the commercetools support team!"
     )


### PR DESCRIPTION
#### Support change master variant

Fix: https://github.com/commercetools/express-impex/issues/752
- User can only set master variant to the existing added variants by moving the variant to the first line

```
id,productType,productTypeKey,name.en,name.de,variantId,sku,variantKey,images,prices,attr1
3f127ae0-65f2-4031-a4f8-0de797f986a2,Test-required-attribute,Test-required-attribute,product1,product1,2,product2sku2,product2skukey,,USD 17,kumar
,,,,,1,product1sku1,product1skukey,,USD 12,vineet
,,,,,4,product1skqweu1,pr12321oduct1skukey,,USD 10,master
```

Here the current master variant is second one(`1,product1sku1,product1skukey,,USD 12,vineet`) and we are changing master variant from 1 to 2


Manual Test case
- Change master variant 
- Change Master variant and update some data with that
- Try to add new variant as master and it should return error
- Verify rest of the existing flow